### PR TITLE
Commit badger transaction synchronously

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -215,10 +215,7 @@ func (t *Triplestore) Put(subject interface{}, predicate interface{}, object int
 	}
 
 	// Commit the transaction
-	txn.Commit(func(e error) {
-		err = e
-	})
-	return err
+	return txn.Commit(nil)
 }
 func (t *Triplestore) toIDs(txn *badger.Txn, subject interface{}, predicate interface{}, object interface{}, b bool) ([]byte, []byte, []byte, error) {
 	// convert all input values to ids
@@ -532,11 +529,7 @@ func (t *Triplestore) Delete(subject interface{}, predicate interface{}, object 
 	txn.Delete(spo)
 	txn.Delete(ops)
 	txn.Delete(sop)
-	err = nil
-	txn.Commit(func(e error) {
-		err = e
-	})
-	return err
+	return txn.Commit(nil)
 }
 
 func (t *Triplestore) DeleteEntity(entity interface{}) (int, error) {
@@ -576,9 +569,5 @@ func (t *Triplestore) DeleteEntity(entity interface{}) (int, error) {
 		txn.Delete(i)
 		c++
 	}
-	err = nil
-	txn.Commit(func(e error) {
-		err = e
-	})
-	return c, err
+	return c, txn.Commit(nil)
 }


### PR DESCRIPTION
If badger.Txn.Commit is called with a non-nil callback it writes to the database in the background. Any error during write will be written to the callback but the local err variable will have gone out-of-scope by then.

For now, I suggest, provide a nil callback and then Commit will write to the database synchronously and Triplestore can handle any error during write. If there is a need to write to the database asynchronously then there needs to be a way of handling the asynchronous error.

This also simplifies the interface between triplestore and badger which might be handy for abstracting out badger for unit tests.